### PR TITLE
Bugfix: Longtexts will be cropped

### DIFF
--- a/lib/dropdown_formfield.dart
+++ b/lib/dropdown_formfield.dart
@@ -48,6 +48,7 @@ class DropDownFormField extends FormField<dynamic> {
                     ),
                     child: DropdownButtonHideUnderline(
                       child: DropdownButton<dynamic>(
+                        isExpanded: true,
                         hint: Text(
                           hintText,
                           style: TextStyle(color: Colors.grey.shade500),
@@ -60,7 +61,8 @@ class DropDownFormField extends FormField<dynamic> {
                         items: dataSource.map((item) {
                           return DropdownMenuItem<dynamic>(
                             value: item[valueField],
-                            child: Text(item[textField]),
+                            child: Text(item[textField],
+                                overflow: TextOverflow.ellipsis),
                           );
                         }).toList(),
                       ),
@@ -69,7 +71,9 @@ class DropDownFormField extends FormField<dynamic> {
                   SizedBox(height: state.hasError ? 5.0 : 0.0),
                   Text(
                     state.hasError ? state.errorText : '',
-                    style: TextStyle(color: Colors.redAccent.shade700, fontSize: state.hasError ? 12.0 : 0.0),
+                    style: TextStyle(
+                        color: Colors.redAccent.shade700,
+                        fontSize: state.hasError ? 12.0 : 0.0),
                   ),
                 ],
               ),


### PR DESCRIPTION
Longtexts will be cropped .. 

![Bildschirmfoto 2020-08-25 um 20 38 38](https://user-images.githubusercontent.com/10545335/91214256-1cb15500-e713-11ea-8dfd-76066a87d08b.png)

Fixed: 

![Bildschirmfoto 2020-08-25 um 20 41 53](https://user-images.githubusercontent.com/10545335/91214501-76198400-e713-11ea-8ad7-ef44272c4117.png)


Longtexts will ne cropped like: 'this Text is to lo...'

Unfortunately I forgot to select an element. 